### PR TITLE
Update README for v2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Interactive helper (`configure_stingar.py`) generates `stingar.env`, `nginx.conf`, and `docker-compose.yml` from `templates/`.
 
-## Release alignment (v2.2.2)
+## Release v2.3
 
-`templates/docker-compose.yml.template` pins all `4warned/*` images to **`v2.2.2`**, matching the current production release layout used in **stingar-development** (`infra/terraform/docker-compose.yml.tpl`): same services, health checks, volumes, `nginx:alpine`, `redis:7-alpine`, and `stingarui` `STINGAR_ENV_PATH`.
+Pins all `4warned/*` images to **`v2.3`**, matching the current production release layout.
 
-To move to a newer release, edit the template and replace `v2.2.2` with the desired tag (and verify with release notes / `stingar-development` `VERSION`).
+To move to a newer release, edit the template and replace `v2.3` with the desired tag (and verify with release notes / `stingar-development` `VERSION`).
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Update README release section from v2.2.2 to v2.3

## Test plan

- [ ] Verify README accurately reflects current template image tags